### PR TITLE
Play nicely with CodePipeline output artifact

### DIFF
--- a/CodePipelineEvent.cs
+++ b/CodePipelineEvent.cs
@@ -28,7 +28,7 @@ namespace ExtractStaticFiles
         public S3Location s3Location { get; set; }
     }
 
-    public class InputArtifact
+    public class Artifact
     {
         public Location location { get; set; }
         public object revision { get; set; }
@@ -45,8 +45,8 @@ namespace ExtractStaticFiles
     public class Data
     {
         public ActionConfiguration actionConfiguration { get; set; }
-        public List<InputArtifact> inputArtifacts { get; set; }
-        public List<object> outputArtifacts { get; set; }
+        public List<Artifact> inputArtifacts { get; set; }
+        public List<Artifact> outputArtifacts { get; set; }
         public ArtifactCredentials artifactCredentials { get; set; }
     }
 


### PR DESCRIPTION
@PaulDMendoza Unpack input to output location provided by CodePipeline, instead of postfixing _output to the input location. This makes it so later stages in the pipeline don't need knowledge of the `_output` location, instead they can blindly use this stage's output as their input.